### PR TITLE
use icons from icon theme

### DIFF
--- a/typstwriter/actions.py
+++ b/typstwriter/actions.py
@@ -31,7 +31,8 @@ class Actions(QtCore.QObject):
         self.open_File.setText("Open File")
 
         self.open_recent_File = QtWidgets.QAction(self)
-        self.open_recent_File.setIcon(QtGui.QIcon.fromTheme(QtGui.QIcon.DocumentOpenRecent, QtGui.QIcon(util.icon_path("recentFile.svg"))))
+        self.open_recent_File.setIcon(QtGui.QIcon.fromTheme(QtGui.QIcon.DocumentOpenRecent,
+                                                            QtGui.QIcon(util.icon_path("recentFile.svg"))))
         self.open_recent_File.setShortcut(QtGui.QKeySequence(QtCore.Qt.CTRL | QtCore.Qt.SHIFT | QtCore.Qt.Key_O))
         self.open_recent_File.setText("Open Recent File")
 
@@ -112,8 +113,10 @@ class Actions(QtCore.QObject):
         self.open_config.setText("Open config file")
 
         self.run = util.TogglingAction(self)
-        self.run.setIcon(QtGui.QIcon.fromTheme(QtGui.QIcon.MediaPlaybackStart, QtGui.QIcon(util.icon_path("start.svg"))), state=QtGui.QIcon.State.Off)
-        self.run.setIcon(QtGui.QIcon.fromTheme(QtGui.QIcon.MediaPlaybackStop, QtGui.QIcon(util.icon_path("stop.svg"))), state=QtGui.QIcon.State.On)
+        self.run.setIcon(QtGui.QIcon.fromTheme(QtGui.QIcon.MediaPlaybackStart,
+                                               QtGui.QIcon(util.icon_path("start.svg"))), state=QtGui.QIcon.State.Off)
+        self.run.setIcon(QtGui.QIcon.fromTheme(QtGui.QIcon.MediaPlaybackStop,
+                                               QtGui.QIcon(util.icon_path("stop.svg"))), state=QtGui.QIcon.State.On)
         self.run.setText("Start", state=QtGui.QIcon.State.Off)
         self.run.setText("Stop", state=QtGui.QIcon.State.On)
         self.run.setShortcut("Ctrl+R")

--- a/typstwriter/actions.py
+++ b/typstwriter/actions.py
@@ -21,69 +21,73 @@ class Actions(QtCore.QObject):
         super().__init__(parent)
 
         self.new_File = QtWidgets.QAction(self)
-        self.new_File.setIcon(QtGui.QIcon(util.icon_path("newFile.svg")))
+        self.new_File.setIcon(QtGui.QIcon.fromTheme(QtGui.QIcon.DocumentNew, QtGui.QIcon(util.icon_path("newFile.svg"))))
         self.new_File.setShortcut(QtGui.QKeySequence.New)
         self.new_File.setText("New File")
 #
         self.open_File = QtWidgets.QAction(self)
         self.open_File.setIcon(QtGui.QIcon(util.icon_path("openFile.svg")))
+        self.open_File.setIcon(QtGui.QIcon.fromTheme(QtGui.QIcon.DocumentOpen, QtGui.QIcon(util.icon_path("openFile.svg"))))
         self.open_File.setShortcut(QtGui.QKeySequence.Open)
         self.open_File.setText("Open File")
 
         self.open_recent_File = QtWidgets.QAction(self)
-        self.open_recent_File.setIcon(QtGui.QIcon(util.icon_path("recentFile.svg")))
+        self.open_recent_File.setIcon(QtGui.QIcon.fromTheme(QtGui.QIcon.DocumentOpenRecent, QtGui.QIcon(util.icon_path("recentFile.svg"))))
         self.open_recent_File.setShortcut(QtGui.QKeySequence(QtCore.Qt.CTRL | QtCore.Qt.SHIFT | QtCore.Qt.Key_O))
         self.open_recent_File.setText("Open Recent File")
 
         self.save = QtWidgets.QAction(self)
-        self.save.setIcon(QtGui.QIcon(util.icon_path("save.svg")))
+        self.save.setIcon(QtGui.QIcon.fromTheme(QtGui.QIcon.DocumentSave, QtGui.QIcon(util.icon_path("save.svg"))))
         self.save.setShortcut(QtGui.QKeySequence.Save)
         self.save.setText("Save")
 
         self.save_as = QtWidgets.QAction(self)
-        self.save_as.setIcon(QtGui.QIcon(util.icon_path("save_as.svg")))
+        self.save_as.setIcon(QtGui.QIcon.fromTheme(QtGui.QIcon.DocumentSaveAs, QtGui.QIcon(util.icon_path("save_as.svg"))))
         self.save_as.setShortcut(QtGui.QKeySequence(QtCore.Qt.CTRL | QtCore.Qt.SHIFT | QtCore.Qt.Key_S))
         self.save_as.setText("Save As")
 
         self.close = QtWidgets.QAction(self)
-        self.close.setIcon(QtGui.QIcon(util.icon_path("closeFile.svg")))
+        self.close.setIcon(QtGui.QIcon.fromTheme("document-close-symbolic", QtGui.QIcon(util.icon_path("closeFile.svg"))))
         self.close.setShortcut(QtGui.QKeySequence.Close)
         self.close.setText("Close")
 
         self.quit = QtWidgets.QAction(self)
-        self.quit.setIcon(QtGui.QIcon(util.icon_path("quit.svg")))
+        self.quit.setIcon(QtGui.QIcon.fromTheme(QtGui.QIcon.ApplicationExit, QtGui.QIcon(util.icon_path("quit.svg"))))
         self.quit.setShortcut(QtGui.QKeySequence.Quit)
         self.quit.setText("Quit")
 
         self.cut = QtWidgets.QAction(self)
-        self.cut.setIcon(QtGui.QIcon(util.icon_path("cut.svg")))
+        self.cut.setIcon(QtGui.QIcon.fromTheme(QtGui.QIcon.EditCut, QtGui.QIcon(util.icon_path("cut.svg"))))
         self.cut.setShortcut(QtGui.QKeySequence.Cut)
         self.cut.setText("Cut")
 
         self.copy = QtWidgets.QAction(self)
-        self.copy.setIcon(QtGui.QIcon(util.icon_path("copy.svg")))
+        self.copy.setIcon(QtGui.QIcon.fromTheme(QtGui.QIcon.EditCopy, QtGui.QIcon(util.icon_path("copy.svg"))))
         self.copy.setShortcut(QtGui.QKeySequence.Copy)
         self.copy.setText("Copy")
 
         self.paste = QtWidgets.QAction(self)
-        self.paste.setIcon(QtGui.QIcon(util.icon_path("paste.svg")))
+        self.paste.setIcon(QtGui.QIcon.fromTheme(QtGui.QIcon.EditPaste, QtGui.QIcon(util.icon_path("paste.svg"))))
         self.paste.setShortcut(QtGui.QKeySequence.Paste)
         self.paste.setText("Paste")
 
         self.search = QtWidgets.QAction(self)
-        self.search.setIcon(QtGui.QIcon(util.icon_path("quit.svg")))
+        self.search.setIcon(QtGui.QIcon.fromTheme(QtGui.QIcon.EditFind, QtGui.QIcon(util.icon_path("quit.svg"))))
         self.search.setShortcut(QtGui.QKeySequence.Find)
         self.search.setText("Search")
 
         self.layout_typewriter = QtWidgets.QAction(self)
+        self.layout_typewriter.setIcon(QtGui.QIcon.fromTheme("view-split-top-bottom-symbolic"))
         self.layout_typewriter.setText("Layout: Typewriter")
         self.layout_typewriter.setCheckable(True)
 
         self.layout_editorL = QtWidgets.QAction(self)
+        self.layout_editorL.setIcon(QtGui.QIcon.fromTheme("view-split-left-right-symbolic"))
         self.layout_editorL.setText("Layout: Editor Left")
         self.layout_editorL.setCheckable(True)
 
         self.layout_editorR = QtWidgets.QAction(self)
+        self.layout_editorR.setIcon(QtGui.QIcon.fromTheme("view-split-left-right-symbolic"))
         self.layout_editorR.setText("Layout: Editor Right")
         self.layout_editorR.setCheckable(True)
 
@@ -105,16 +109,12 @@ class Actions(QtCore.QObject):
         self.show_compiler_output.setCheckable(True)
 
         self.open_config = QtWidgets.QAction(self)
+        self.open_config.setIcon(QtGui.QIcon.fromTheme("configure-symbolic"))
         self.open_config.setText("Open config file")
 
         self.run = util.TogglingAction(self)
-        icon = QtGui.QIcon()
-        icon.addFile(util.icon_path("start.svg"), state=QtGui.QIcon.State.Off)
-        icon.addFile(util.icon_path("stop.svg"), state=QtGui.QIcon.State.On)
-        self.run.setIcon(icon)
+        self.run.setIcon(QtGui.QIcon.fromTheme(QtGui.QIcon.MediaPlaybackStart, QtGui.QIcon(util.icon_path("start.svg"))), state=QtGui.QIcon.State.Off)
+        self.run.setIcon(QtGui.QIcon.fromTheme(QtGui.QIcon.MediaPlaybackStop, QtGui.QIcon(util.icon_path("stop.svg"))), state=QtGui.QIcon.State.On)
         self.run.setText("Start", state=QtGui.QIcon.State.Off)
         self.run.setText("Stop", state=QtGui.QIcon.State.On)
         self.run.setShortcut("Ctrl+R")
-
-
-

--- a/typstwriter/actions.py
+++ b/typstwriter/actions.py
@@ -26,7 +26,6 @@ class Actions(QtCore.QObject):
         self.new_File.setText("New File")
 #
         self.open_File = QtWidgets.QAction(self)
-        self.open_File.setIcon(QtGui.QIcon(util.icon_path("openFile.svg")))
         self.open_File.setIcon(QtGui.QIcon.fromTheme(QtGui.QIcon.DocumentOpen, QtGui.QIcon(util.icon_path("openFile.svg"))))
         self.open_File.setShortcut(QtGui.QKeySequence.Open)
         self.open_File.setText("Open File")

--- a/typstwriter/actions.py
+++ b/typstwriter/actions.py
@@ -31,8 +31,9 @@ class Actions(QtCore.QObject):
         self.open_File.setText("Open File")
 
         self.open_recent_File = QtWidgets.QAction(self)
-        self.open_recent_File.setIcon(QtGui.QIcon.fromTheme(QtGui.QIcon.DocumentOpenRecent,
-                                                            QtGui.QIcon(util.icon_path("recentFile.svg"))))
+        self.open_recent_File.setIcon(
+            QtGui.QIcon.fromTheme(QtGui.QIcon.DocumentOpenRecent, QtGui.QIcon(util.icon_path("recentFile.svg")))
+        )
         self.open_recent_File.setShortcut(QtGui.QKeySequence(QtCore.Qt.CTRL | QtCore.Qt.SHIFT | QtCore.Qt.Key_O))
         self.open_recent_File.setText("Open Recent File")
 
@@ -113,10 +114,14 @@ class Actions(QtCore.QObject):
         self.open_config.setText("Open config file")
 
         self.run = util.TogglingAction(self)
-        self.run.setIcon(QtGui.QIcon.fromTheme(QtGui.QIcon.MediaPlaybackStart,
-                                               QtGui.QIcon(util.icon_path("start.svg"))), state=QtGui.QIcon.State.Off)
-        self.run.setIcon(QtGui.QIcon.fromTheme(QtGui.QIcon.MediaPlaybackStop,
-                                               QtGui.QIcon(util.icon_path("stop.svg"))), state=QtGui.QIcon.State.On)
+        self.run.setIcon(
+            QtGui.QIcon.fromTheme(QtGui.QIcon.MediaPlaybackStart, QtGui.QIcon(util.icon_path("start.svg"))),
+            state=QtGui.QIcon.State.Off,
+        )
+        self.run.setIcon(
+            QtGui.QIcon.fromTheme(QtGui.QIcon.MediaPlaybackStop, QtGui.QIcon(util.icon_path("stop.svg"))),
+            state=QtGui.QIcon.State.On,
+        )
         self.run.setText("Start", state=QtGui.QIcon.State.Off)
         self.run.setText("Stop", state=QtGui.QIcon.State.On)
         self.run.setShortcut("Ctrl+R")

--- a/typstwriter/compiler_tools.py
+++ b/typstwriter/compiler_tools.py
@@ -53,7 +53,8 @@ class CompilerOptions(QtWidgets.QWidget):
         self.line_edit_main = QtWidgets.QLineEdit(self)
         self.line_edit_main.setText("")
         self.line_edit_main.editingFinished.connect(self.main_path_edited)
-        self.folderAction = QtWidgets.QAction(QtGui.QIcon.fromTheme(QtGui.QIcon.FolderOpen ,QtGui.QIcon(util.icon_path("folder.svg"))), "open")
+        self.folderAction = QtWidgets.QAction(QtGui.QIcon.fromTheme(QtGui.QIcon.FolderOpen
+                                                                    ,QtGui.QIcon(util.icon_path("folder.svg"))), "open")
         self.folderAction.triggered.connect(self.open_file_dialog)
         self.line_edit_main.addAction(self.folderAction, QtWidgets.QLineEdit.LeadingPosition)
 

--- a/typstwriter/compiler_tools.py
+++ b/typstwriter/compiler_tools.py
@@ -53,8 +53,9 @@ class CompilerOptions(QtWidgets.QWidget):
         self.line_edit_main = QtWidgets.QLineEdit(self)
         self.line_edit_main.setText("")
         self.line_edit_main.editingFinished.connect(self.main_path_edited)
-        self.folderAction = QtWidgets.QAction(QtGui.QIcon.fromTheme(QtGui.QIcon.FolderOpen
-                                                                    ,QtGui.QIcon(util.icon_path("folder.svg"))), "open")
+        self.folderAction = QtWidgets.QAction(
+            QtGui.QIcon.fromTheme(QtGui.QIcon.FolderOpen, QtGui.QIcon(util.icon_path("folder.svg"))), "open"
+        )
         self.folderAction.triggered.connect(self.open_file_dialog)
         self.line_edit_main.addAction(self.folderAction, QtWidgets.QLineEdit.LeadingPosition)
 

--- a/typstwriter/compiler_tools.py
+++ b/typstwriter/compiler_tools.py
@@ -53,7 +53,7 @@ class CompilerOptions(QtWidgets.QWidget):
         self.line_edit_main = QtWidgets.QLineEdit(self)
         self.line_edit_main.setText("")
         self.line_edit_main.editingFinished.connect(self.main_path_edited)
-        self.folderAction = QtWidgets.QAction(QtGui.QIcon(util.icon_path("folder.svg")), "open")
+        self.folderAction = QtWidgets.QAction(QtGui.QIcon.fromTheme(QtGui.QIcon.FolderOpen ,QtGui.QIcon(util.icon_path("folder.svg"))), "open")
         self.folderAction.triggered.connect(self.open_file_dialog)
         self.line_edit_main.addAction(self.folderAction, QtWidgets.QLineEdit.LeadingPosition)
 

--- a/typstwriter/editor.py
+++ b/typstwriter/editor.py
@@ -53,7 +53,7 @@ class Editor(QtWidgets.QFrame):
         """Open a new, empty file."""
         editorpage = EditorPage()
         name = "*new*"
-        icon = QtGui.QIcon.fromTheme(QtGui.QIcon.DocumentNew,QtGui.QIcon(util.icon_path("newFile.svg")))
+        icon = QtGui.QIcon.fromTheme(QtGui.QIcon.DocumentNew, QtGui.QIcon(util.icon_path("newFile.svg")))
         self.TabWidget.addTab(editorpage, icon, name)
         self.TabWidget.setCurrentIndex(self.TabWidget.count() - 1)
         self.TabWidget.tabBar().setTabTextColor(self.TabWidget.count() - 1, QtGui.QColor("green"))
@@ -332,7 +332,7 @@ class EditorPage(QtWidgets.QFrame):
         self.gridLayout = QtWidgets.QGridLayout()
 
         self.label_w = QtWidgets.QLabel()
-        if(QtGui.QIcon.hasThemeIcon("data-warning")):
+        if QtGui.QIcon.hasThemeIcon("data-warning"):
             self.label_w.setPixmap(QtGui.QIcon.fromTheme("data-warning").pixmap(64))
         else:
             self.label_w.setPixmap(QtGui.QPixmap(util.icon_path("warning.svg")))

--- a/typstwriter/editor.py
+++ b/typstwriter/editor.py
@@ -333,8 +333,8 @@ class EditorPage(QtWidgets.QFrame):
         self.gridLayout = QtWidgets.QGridLayout()
 
         self.label_w = QtWidgets.QLabel()
-        if(QtGui.QIcon.hasThemeIcon(QtGui.QIcon.DialogWarning)):
-            self.label_w.setPixmap(QtGui.QIcon.fromTheme(QtGui.QIcon.DialogWarning).pixmap(64))
+        if(QtGui.QIcon.hasThemeIcon("data-warning")):
+            self.label_w.setPixmap(QtGui.QIcon.fromTheme("data-warning").pixmap(64))
         else:
             self.label_w.setPixmap(QtGui.QPixmap(util.icon_path("warning.svg")))
         self.label_t = QtWidgets.QLabel("<h1>" + msg + "</h1>")

--- a/typstwriter/editor.py
+++ b/typstwriter/editor.py
@@ -53,7 +53,7 @@ class Editor(QtWidgets.QFrame):
         """Open a new, empty file."""
         editorpage = EditorPage()
         name = "*new*"
-        icon = QtGui.QIcon(util.icon_path("newFile.svg"))
+        icon = QtGui.QIcon.fromTheme(QtGui.QIcon.DocumentNew,QtGui.QIcon(util.icon_path("newFile.svg")))
         self.TabWidget.addTab(editorpage, icon, name)
         self.TabWidget.setCurrentIndex(self.TabWidget.count()-1)
         self.TabWidget.tabBar().setTabTextColor(self.TabWidget.count()-1, QtGui.QColor("green"))
@@ -333,7 +333,10 @@ class EditorPage(QtWidgets.QFrame):
         self.gridLayout = QtWidgets.QGridLayout()
 
         self.label_w = QtWidgets.QLabel()
-        self.label_w.setPixmap(QtGui.QPixmap(util.icon_path("warning.svg")))
+        if(QtGui.QIcon.hasThemeIcon(QtGui.QIcon.DialogWarning)):
+            self.label_w.setPixmap(QtGui.QIcon.fromTheme(QtGui.QIcon.DialogWarning).pixmap(64))
+        else:
+            self.label_w.setPixmap(QtGui.QPixmap(util.icon_path("warning.svg")))
         self.label_t = QtWidgets.QLabel("<h1>" + msg + "</h1>")
 
         self.gridLayout.addWidget(self.label_w, 0, 1)

--- a/typstwriter/fs_explorer.py
+++ b/typstwriter/fs_explorer.py
@@ -130,7 +130,7 @@ class FSExplorer(QtWidgets.QWidget):
         self.pathBar = QtWidgets.QLineEdit(self)
         self.pathBar.setText("")
         self.pathBar.editingFinished.connect(self.line_edited)
-        self.folderAction = QtWidgets.QAction(QtGui.QIcon(util.icon_path("folder.svg")), "open")
+        self.folderAction = QtWidgets.QAction(QtGui.QIcon.fromTheme(QtGui.QIcon.FolderOpen, QtGui.QIcon(util.icon_path("folder.svg"))), "open")
         self.folderAction.triggered.connect(self.open_directory_dialog)
         self.pathBar.addAction(self.folderAction, QtWidgets.QLineEdit.LeadingPosition)
 

--- a/typstwriter/fs_explorer.py
+++ b/typstwriter/fs_explorer.py
@@ -130,8 +130,9 @@ class FSExplorer(QtWidgets.QWidget):
         self.pathBar = QtWidgets.QLineEdit(self)
         self.pathBar.setText("")
         self.pathBar.editingFinished.connect(self.line_edited)
-        self.folderAction = QtWidgets.QAction(QtGui.QIcon.fromTheme(QtGui.QIcon.FolderOpen,
-                                                                    QtGui.QIcon(util.icon_path("folder.svg"))), "open")
+        self.folderAction = QtWidgets.QAction(
+            QtGui.QIcon.fromTheme(QtGui.QIcon.FolderOpen, QtGui.QIcon(util.icon_path("folder.svg"))), "open"
+        )
         self.folderAction.triggered.connect(self.open_directory_dialog)
         self.pathBar.addAction(self.folderAction, QtWidgets.QLineEdit.LeadingPosition)
 

--- a/typstwriter/fs_explorer.py
+++ b/typstwriter/fs_explorer.py
@@ -130,7 +130,8 @@ class FSExplorer(QtWidgets.QWidget):
         self.pathBar = QtWidgets.QLineEdit(self)
         self.pathBar.setText("")
         self.pathBar.editingFinished.connect(self.line_edited)
-        self.folderAction = QtWidgets.QAction(QtGui.QIcon.fromTheme(QtGui.QIcon.FolderOpen, QtGui.QIcon(util.icon_path("folder.svg"))), "open")
+        self.folderAction = QtWidgets.QAction(QtGui.QIcon.fromTheme(QtGui.QIcon.FolderOpen,
+                                                                    QtGui.QIcon(util.icon_path("folder.svg"))), "open")
         self.folderAction.triggered.connect(self.open_directory_dialog)
         self.pathBar.addAction(self.folderAction, QtWidgets.QLineEdit.LeadingPosition)
 

--- a/typstwriter/menubar.py
+++ b/typstwriter/menubar.py
@@ -75,7 +75,7 @@ class RecentFilesMenu(QtWidgets.QMenu):
         """Init."""
         QtWidgets.QMenu.__init__(self)
 
-        self.setIcon(QtGui.QIcon(util.icon_path("recentFile.svg")))
+        self.setIcon(QtGui.QIcon.fromTheme(QtGui.QIcon.DocumentOpenRecent, QtGui.QIcon(util.icon_path("recentFile.svg"))))
         self.setTitle("Open recent file")
 
         self.addAction("")

--- a/typstwriter/pdf_viewer.py
+++ b/typstwriter/pdf_viewer.py
@@ -104,7 +104,8 @@ class PDFViewer(QtWidgets.QFrame):
 
         # Action Previous Page
         self.actionPrevious_Page = QtGui.QAction(self)
-        self.actionPrevious_Page.setIcon(QtGui.QIcon.fromTheme(QtGui.QIcon.GoPrevious, QtGui.QIcon(util.icon_path("larrow.svg"))))
+        self.actionPrevious_Page.setIcon(QtGui.QIcon.fromTheme(QtGui.QIcon.GoPrevious,
+                                                               QtGui.QIcon(util.icon_path("larrow.svg"))))
         self.actionPrevious_Page.setText("Previous Page")
 
         # Action Next Page

--- a/typstwriter/pdf_viewer.py
+++ b/typstwriter/pdf_viewer.py
@@ -104,8 +104,9 @@ class PDFViewer(QtWidgets.QFrame):
 
         # Action Previous Page
         self.actionPrevious_Page = QtGui.QAction(self)
-        self.actionPrevious_Page.setIcon(QtGui.QIcon.fromTheme(QtGui.QIcon.GoPrevious,
-                                                               QtGui.QIcon(util.icon_path("larrow.svg"))))
+        self.actionPrevious_Page.setIcon(
+            QtGui.QIcon.fromTheme(QtGui.QIcon.GoPrevious, QtGui.QIcon(util.icon_path("larrow.svg")))
+        )
         self.actionPrevious_Page.setText("Previous Page")
 
         # Action Next Page

--- a/typstwriter/pdf_viewer.py
+++ b/typstwriter/pdf_viewer.py
@@ -92,30 +92,30 @@ class PDFViewer(QtWidgets.QFrame):
 
         # Action Zoom In
         self.actionZoom_In = QtGui.QAction(self)
-        self.actionZoom_In.setIcon(QtGui.QIcon(util.icon_path("plus.svg")))
+        self.actionZoom_In.setIcon(QtGui.QIcon.fromTheme(QtGui.QIcon.ZoomIn, QtGui.QIcon(util.icon_path("plus.svg"))))
         self.actionZoom_In.setText("Zoom In")
         self.actionZoom_In.setShortcut("Ctrl++")
 
         # Action Zoom Out
         self.actionZoom_Out = QtGui.QAction(self)
-        self.actionZoom_Out.setIcon(QtGui.QIcon(util.icon_path("minus.svg")))
+        self.actionZoom_Out.setIcon(QtGui.QIcon.fromTheme(QtGui.QIcon.ZoomOut, QtGui.QIcon(util.icon_path("minus.svg"))))
         self.actionZoom_Out.setText("Zoom Out")
         self.actionZoom_Out.setShortcut("Ctrl+-")
 
         # Action Previous Page
         self.actionPrevious_Page = QtGui.QAction(self)
-        self.actionPrevious_Page.setIcon(QtGui.QIcon(util.icon_path("larrow.svg")))
+        self.actionPrevious_Page.setIcon(QtGui.QIcon.fromTheme(QtGui.QIcon.GoPrevious, QtGui.QIcon(util.icon_path("larrow.svg"))))
         self.actionPrevious_Page.setText("Previous Page")
 
         # Action Next Page
         self.actionNext_Page = QtGui.QAction(self)
-        self.actionNext_Page.setIcon(QtGui.QIcon(util.icon_path("rarrow.svg")))
+        self.actionNext_Page.setIcon(QtGui.QIcon.fromTheme(QtGui.QIcon.GoNext, QtGui.QIcon(util.icon_path("rarrow.svg"))))
         self.actionNext_Page.setText("Next Page")
         self.actionPrevious_Page.setShortcut("PgUp")
 
         # Action External Viewer
         self.actionOpen_External = QtGui.QAction(self)
-        self.actionOpen_External.setIcon(QtGui.QIcon(util.icon_path("pdf.svg")))
+        self.actionOpen_External.setIcon(QtGui.QIcon.fromTheme("viewpdf", QtGui.QIcon(util.icon_path("pdf.svg"))))
         self.actionOpen_External.setText("External Viewer")
         self.actionNext_Page.setShortcut("PgDown")
 

--- a/typstwriter/util.py
+++ b/typstwriter/util.py
@@ -160,6 +160,7 @@ class TogglingAction(QtWidgets.QAction):
         self.text_on = ""
         self.text_off = ""
         self.toggled.connect(self.update_text)  # User or progammatic interaction
+        self.toggled.connect(self.update_icon)  # User or progammatic interaction
         self.triggered.connect(self.handle_triggered)  # User interaction
 
     def setIcon(self, icon, state=None):

--- a/typstwriter/util.py
+++ b/typstwriter/util.py
@@ -155,10 +155,19 @@ class TogglingAction(QtWidgets.QAction):
         """Init."""
         QtWidgets.QAction.__init__(self, parent)
         self.setCheckable(True)
+        self.icon_on = QtGui.QIcon
+        self.icon_off = QtGui.QIcon
         self.text_on = ""
         self.text_off = ""
         self.toggled.connect(self.update_text)  # User or progammatic interaction
         self.triggered.connect(self.handle_triggered)  # User interaction
+
+    def setIcon(self, icon, state=None):
+        if state == QtGui.QIcon.State.On or state is None:
+            self.icon_on = icon
+        if state == QtGui.QIcon.State.Off or state is None:
+            self.icon_off = icon
+        self.update_icon()
 
     def setText(self, text, state=None): # noqa N802
         """Extend parent setText with state information."""
@@ -167,6 +176,12 @@ class TogglingAction(QtWidgets.QAction):
         if state == QtGui.QIcon.State.Off or state is None:
             self.text_off = text
         self.update_text()
+
+    def update_icon(self):
+        if self.isChecked() is True:
+            super().setIcon(self.icon_on)
+        else:
+            super().setIcon(self.icon_off)
 
     def update_text(self):
         """Update text when toggling."""
@@ -178,6 +193,7 @@ class TogglingAction(QtWidgets.QAction):
     def handle_triggered(self, checked):
         """Handle toggling."""
         self.update_text()
+        self.update_icon()
         if checked:
             self.activated.emit()
         else:

--- a/typstwriter/util.py
+++ b/typstwriter/util.py
@@ -163,7 +163,8 @@ class TogglingAction(QtWidgets.QAction):
         self.toggled.connect(self.update_icon)  # User or progammatic interaction
         self.triggered.connect(self.handle_triggered)  # User interaction
 
-    def setIcon(self, icon, state=None):
+    def setIcon(self, icon, state=None): # noqa N802
+        """Extend parent setIcon with state information."""
         if state == QtGui.QIcon.State.On or state is None:
             self.icon_on = icon
         if state == QtGui.QIcon.State.Off or state is None:
@@ -179,6 +180,7 @@ class TogglingAction(QtWidgets.QAction):
         self.update_text()
 
     def update_icon(self):
+        """Update icon when toggling."""
         if self.isChecked() is True:
             super().setIcon(self.icon_on)
         else:

--- a/typstwriter/util.py
+++ b/typstwriter/util.py
@@ -163,7 +163,7 @@ class TogglingAction(QtWidgets.QAction):
         self.toggled.connect(self.update_icon)  # User or progammatic interaction
         self.triggered.connect(self.handle_triggered)  # User interaction
 
-    def setIcon(self, icon, state=None): # noqa N802
+    def setIcon(self, icon, state=None):  # noqa N802
         """Extend parent setIcon with state information."""
         if state == QtGui.QIcon.State.On or state is None:
             self.icon_on = icon

--- a/typstwriter/util.py
+++ b/typstwriter/util.py
@@ -155,8 +155,8 @@ class TogglingAction(QtWidgets.QAction):
         """Init."""
         QtWidgets.QAction.__init__(self, parent)
         self.setCheckable(True)
-        self.icon_on = QtGui.QIcon
-        self.icon_off = QtGui.QIcon
+        self.icon_on = QtGui.QIcon()
+        self.icon_off = QtGui.QIcon()
         self.text_on = ""
         self.text_off = ""
         self.toggled.connect(self.update_text)  # User or progammatic interaction


### PR DESCRIPTION
This commit makes the app try to use the icons from the current icon theme, and falls back to the bundled ones if none is available.

Icon recoloring is not supported, so themes relying on it (e.g. breeze dark) will look broken (dark icons on dark background). Note that the current implementation always use dark icons even when using a dark color scheme.