### PR TITLE
Adapt to ruff version 0.5.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ indent-width = 4
 
 [tool.ruff.lint]
 select = ["E", "F", "W", "N", "D", "Q", "PL", "R", "C", "B", "C4", "G", "PT", "RET", "RUF", "SIM", "UP"]
-ignore = ["D212", "D203", "D400", "RET505", "D100", "PLR0915", "RET504", "PLE1205", "UP015"]
+ignore = ["D212", "D203", "D400", "RET505", "D100", "PLR0915", "RET504", "PLE1205", "UP015", "PLC2401"]
 
 [tool.ruff.format]
 quote-style = "double"

--- a/typstwriter/typstwriter.py
+++ b/typstwriter/typstwriter.py
@@ -4,7 +4,7 @@ import os
 
 
 os.environ["QT_API"] = "pyside6"
-import qtpy  # noqa: E402
+import qtpy  # noqa: E402 RUF100
 
 
 def main():


### PR DESCRIPTION
Changes relevant for typstwriter:
* module-import-not-at-top-of-file (E402) now allows os.environ modifications between import statements: Makes noqa in typstwriter.py unnecessary. Keep it for now for backward compatibility.
* non-ascii-name (PLC2401) disallows non-ASCII characters in variable names: Ignore this rule