### PR TITLE
Improve example config

### DIFF
--- a/docs/example_config.ini
+++ b/docs/example_config.ini
@@ -1,34 +1,37 @@
 [General]
-#The standard working directory.
+# Configure the working directory on startup
 working_directory = ~/Documents/typst_projects/
-#The default application layout.
-#It can be typewriter (editor under preview), editor_right (editor right of preview) or editor_left (editor left of preview).
+# Use . to start from the current directory the program was started from
+# working_directory = .
+
+# The default application layout
+# It can be typewriter (editor under preview), editor_right (editor right of preview) or editor_left (editor left of preview)
 default_layout = typewriter
 
 [Compiler]
-#The name of the typst compiler on your system (in almost all cases simply typst).
-#You can also provide an absolute path to the typst executable, e.g.:
-#name = /home/username/Code/typst/target/release/typst
+# The name of the typst compiler on your system (in almost all cases simply typst)
+# You can also provide an absolute path to the typst executable, e.g.:
+# name = /home/username/Code/typst/target/release/typst
 name = typst
-#The compiler mode (live/on_demand)
+# The compiler mode (live/on_demand)
 mode = live
 
 [Editor]
-#Save all open tabs before compiling
+# Save all open tabs before compiling
 save_at_run = True
-#The code highlighter style to use. See https://pygments.org/styles/ for available options.
+# The code highlighter style to use. See https://pygments.org/styles/ for available options
 highlighter_style = staroffice
-#Use syntax highlighting.
+# Use syntax highlighting
 highlight_syntax = True
-#Show line numbers.
+# Show line numbers
 show_line_numbers = True
-#Highlight the current line.
+# Highlight the current line
 highlight_line = True
-#Use spaces instead of tabs.
+# Use spaces instead of tabs
 use_spaces = True
 
 [Internals]
-#The path where the list of recent files will be saved.
+# The path where the list of recent files will be saved
 recent_files_path = ~/.config/typstwriter/recentFiles.txt
-#The number of files kept in the list.
+# The number of recently opened files to remember
 recent_files_length = 16

--- a/docs/example_config.ini
+++ b/docs/example_config.ini
@@ -10,9 +10,9 @@ default_layout = typewriter
 
 [Compiler]
 # The name of the typst compiler on your system (in almost all cases simply typst)
-# You can also provide an absolute path to the typst executable, e.g.:
-# name = /home/username/Code/typst/target/release/typst
 name = typst
+# Alternatively one can provide an absolute path to the typst executable, e.g.:
+# name = /home/username/Code/typst/target/release/typst
 # The compiler mode (live/on_demand)
 mode = live
 


### PR DESCRIPTION
Hello,

Here is a small change in the example config. It might be useful to others to see how to start it from CWD instead of a static folder.

I've also added a space after the `#` character, as it's visually more pleasing/readable, and generally what you'll find in most config files. As well as remove the dot at the end, but this is purely a personal preference to lighten it.

=========

* add example for starting in current working directory
* add a space after initial # character
* remove trailing dots
* change formulation for number of recently opened files kept



