### PR TITLE
Use platformdirs to determine config and data paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,9 @@ Typstwriter looks for configuration files in the following locations:
 
 * /etc/typstwriter/typstwriter.ini
 * /usr/local/etc/typstwriter/typstwriter.ini
-* ~/.config/typstwriter/typstwriter.ini
+* Platform specific configuration directory:
+	* $XDG_CONFIG_HOME/typstwriter/typstwriter.ini
+	* %USERPROFILE%\AppData\Local\typstwriter\typstwriter\typstwriter.ini
 * ~/.typstwriter.ini
 * ./typstwriter.ini
 

--- a/docs/example_config.ini
+++ b/docs/example_config.ini
@@ -41,6 +41,6 @@ show_compiler_output = True
 
 [Internals]
 # The path where the list of recent files will be saved
-recent_files_path = ~/.config/typstwriter/recentFiles.txt
+recent_files_path = ~/.local/share/typstwriter/recentFiles.txt
 # The number of recently opened files to remember
 recent_files_length = 16

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
 "qtpy >= 2.3",
 "pyside6 >= 6.4.0",
 "pygments >= 2.18",
+"platformdirs >= 4.0"
 ]
 dynamic = ["version"]
 

--- a/typstwriter/configuration.py
+++ b/typstwriter/configuration.py
@@ -1,12 +1,15 @@
 import os
 import configparser
 
+import platformdirs
+
 from typstwriter import logging
 
 logger = logging.getLogger(__name__)
 
 
-default_config_path = os.path.expanduser("~/.config/typstwriter/typstwriter.ini")
+default_config_path = os.path.join(platformdirs.user_config_dir("typstwriter", "typstwriter"), "typstwriter.ini")
+default_recent_files_path = os.path.join(platformdirs.user_data_dir("typstwriter", "typstwriter"), "recentFiles.txt")
 
 config_paths = ["/etc/typstwriter/typstwriter.ini",
                 "/usr/local/etc/typstwriter/typstwriter.ini",
@@ -28,7 +31,7 @@ default_config = {"General": {"working_directory": "~/"},
                              "show_fs_explorer": True,
                              "show_compiler_options": True,
                              "show_compiler_output": True},
-                  "Internals": {"recent_files_path": "~/.config/typstwriter/recentFiles.txt",
+                  "Internals": {"recent_files_path": default_recent_files_path,
                                 "recent_files_length": 16}}  # fmt: skip
 
 


### PR DESCRIPTION
This will make Typstwriter use appropriate directories on different platforms and adhere to the XDG Base Directory specification.