### PR TITLE
Select search text when opening search bar.

### DIFF
--- a/typstwriter/editor.py
+++ b/typstwriter/editor.py
@@ -197,6 +197,7 @@ class Editor(QtWidgets.QFrame):
         page = self.TabWidget.currentWidget()
         if isinstance(page, EditorPage):
             page.search_bar.show()
+            page.search_bar.edit_search.setSelection(0, len(page.search_bar.edit_search.text()))
             # page.search_bar.edit_search.setFocus()
 
     @QtCore.Slot()


### PR DESCRIPTION
A minor convenience feature to select the previous search text when opening the search bar or pressing `CTRL+F` such that one can immediately type the new search text instead of having to delete the old one first.