### PR TITLE
Use theme's base background for compiler tools

### DIFF
--- a/typstwriter/compiler_tools.py
+++ b/typstwriter/compiler_tools.py
@@ -29,10 +29,8 @@ class CompilerOptions(QtWidgets.QWidget):
 
         self.HostWidget = QtWidgets.QFrame(self)
         self.HostWidget.setFrameStyle(QtWidgets.QFrame.Shape.StyledPanel)
-        palette = self.HostWidget.palette()
-        palette.setColor(QtGui.QPalette.ColorRole.Window, QtGui.QColor("white"))
+        self.HostWidget.setBackgroundRole(QtGui.QPalette.ColorRole.Base)
         self.HostWidget.setAutoFillBackground(True)
-        self.HostWidget.setPalette(palette)
         self.FrameLayout.addWidget(self.HostWidget)
 
         self.Layout = QtWidgets.QGridLayout(self.HostWidget)


### PR DESCRIPTION
Instead of hardcoding a white background

With breeze light:
<img width="2002" height="1132" alt="breeze-light" src="https://github.com/user-attachments/assets/b17c6588-eedc-4686-9f05-1b0f62d70454" />

With breeze dark:
<img width="2002" height="1132" alt="breeze-dark" src="https://github.com/user-attachments/assets/5642fc9c-8865-49a2-bb4b-3f5f06eee5ef" />
