### PR TITLE
doc: example: fix comments

### DIFF
--- a/docs/example_config.ini
+++ b/docs/example_config.ini
@@ -3,11 +3,11 @@
 # Use . to start from the current directory the program was started from
 working_directory = ~/Documents/typst_projects/
 # working_directory = .
-#resume last session on startup
+# Resume last session on startup
 resume_last_session = True
 
 [Compiler]
-# The name of the typst compiler on your system (in almost all cases simply typst)
+# The name of the Typst compiler on your system (in almost all cases simply typst)
 name = typst
 # Alternatively one can provide an absolute path to the typst executable, e.g.:
 # name = /home/username/Code/typst/target/release/typst
@@ -34,11 +34,11 @@ use_spaces = True
 # The default application layout
 # It can be typewriter (editor under preview), editor_right (editor right of preview) or editor_left (editor left of preview)
 default_layout = typewriter
-# Show the filesystem explorer at startup
+# Show the file system explorer on startup
 show_fs_explorer = True
-# Show the filesystem explorer at startup
+# Show compiler options on startup
 show_compiler_options = True
-# Show the filesystem explorer at startup
+# Show compiler output on startup
 show_compiler_output = True
 
 [Internals]


### PR DESCRIPTION
* fix capitalization
* use "on startup" instead of "at startup"
* fix incorrect comments coming from copy/pasting for startup options